### PR TITLE
Add license metadata to PyPI package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include byudml/metafeature_extraction/metalearn_to_d3m_map.json
 include byudml/profiler/model.zip
+include LICENSE

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     description = 'A collection of DARPA D3M primitives developed by BYU',
     author = 'Roland Laboulaye, Brandom Schoenfeld, Jarom Christensen',
     url = 'https://github.com/byu-dml/d3m-primitives',
+    license = 'MIT',
     include_package_data=True,
     keywords = ['metalearning', 'metafeature', 'machine learning', 'metalearn', 'd3m_primitive'],
     install_requires = [


### PR DESCRIPTION
The package shows as `UNKNOWN` right now and people have to come to the repository to find the LICENSE file.